### PR TITLE
fix: update peerDependencies to include react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "react": "^17.0.1"
+    "react": ">=17.0.1"
   }
 }


### PR DESCRIPTION
This commit makes us able to run `npm install spin-delay` without facing peerDependencies error when we use `react 18` in the project.