### PR TITLE
Support SSR mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,23 @@ export const defaultOptions = {
   minDuration: 200,
 };
 
+function useIsServer() {
+  const [isServer, setIsServer] = useState(true);
+  
+  useEffect(() => {
+    setIsServer(false);
+  }, []);
+
+  return isServer;
+}
+
 export function useSpinDelay(
   loading: boolean,
   options?: SpinDelayOptions,
 ): boolean {
   options = Object.assign({}, defaultOptions, options);
 
+  const isServer = useIsServer();
   const [state, setState] = useState<State>('IDLE');
   const timeout = useRef(null);
 
@@ -49,6 +60,10 @@ export function useSpinDelay(
   useEffect(() => {
     return () => clearTimeout(timeout.current);
   }, []);
+
+  if (isServer) {
+    return loading;
+  }
 
   return state === 'DISPLAY' || state === 'EXPIRE';
 }


### PR DESCRIPTION
### Description
In SSR mode, `useSpinDelay` always returns `false` even though `loading` = `true` because `useEffect` is not executed in SSR mode.

### Solution
Return the value of the `loading` variable in SSR mode.