### PR TITLE
fix(ts): remove default export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,4 +10,3 @@ export declare function useSpinDelay(
   loading: boolean,
   options?: SpinDelayOptions,
 ): boolean;
-export default useSpinDelay;


### PR DESCRIPTION
With the way things are built, at runtime the `default` isn't set properly and isn't interpreted as a default export in any project I've tried this in.

Having this in place though means that whenever I have VSCode auto-import, it uses the default import instead of the named one and then I end up with a runtime error. So then I've got to manually switch it to a named import.

Besides, default exports are the worst.