### PR TITLE
fix: remove default export

### DIFF
--- a/.changeset/short-moles-taste.md
+++ b/.changeset/short-moles-taste.md
@@ -1,0 +1,12 @@
+---
+'spin-delay': major
+---
+
+We've to removed the default export. Please update your code to use the named
+export instead. This is a breaking change, but it's a minor one. Chances are
+that you're already using the named export, and you don't have to do anything.
+
+```diff
+- import useSpinDelay from 'spin-delay';
++ import { useSpinDelay } from 'spin-delay';
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,5 +52,3 @@ export function useSpinDelay(
 
   return state === 'DISPLAY' || state === 'EXPIRE';
 }
-
-export default useSpinDelay;


### PR DESCRIPTION
Given that we used named and default exports together, consumers of our bundle might have run into issues as described in #5. This PR removes the default export from the codebase. Consumers need to switch to named imports instead, if they haven't already.


```diff
- import useSpinDelay from 'spin-delay';
+ import { useSpinDelay } from 'spin-delay';
```