### PR TITLE
feat: add support for SSR

### DIFF
--- a/.changeset/fresh-monkeys-yell.md
+++ b/.changeset/fresh-monkeys-yell.md
@@ -1,0 +1,13 @@
+---
+'spin-delay': major
+---
+
+We now support spinner initialization from the server (SSR). When the `loading` prop is `true` due to server-side rendering, the spinner will be shown immediately. You can opt-out of this behavior by setting the `ssr` option to `false`.
+
+```tsx
+import { useSpinDelay } from 'spin-delay';
+
+const spin = useSpinDelay(loading, {
+  ssr: false, // defaults to true
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,23 @@ export const defaultOptions = {
   minDuration: 200,
 };
 
+function useIsServer() {
+  const [isServer, setIsServer] = useState(true);
+  
+  useEffect(() => {
+    setIsServer(false);
+  }, []);
+
+  return isServer;
+}
+
 export function useSpinDelay(
   loading: boolean,
   options?: SpinDelayOptions,
 ): boolean {
   options = Object.assign({}, defaultOptions, options);
 
+  const isServer = useIsServer();
   const [state, setState] = useState<State>('IDLE');
   const timeout = useRef(null);
 
@@ -49,6 +60,10 @@ export function useSpinDelay(
   useEffect(() => {
     return () => clearTimeout(timeout.current);
   }, []);
+
+  if (isServer) {
+    return loading;
+  }
 
   return state === 'DISPLAY' || state === 'EXPIRE';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,20 +52,18 @@ export function useSpinDelay(
     if (loading && (state === 'IDLE' || isSSR)) {
       clearTimeout(timeout.current);
 
-      timeout.current = setTimeout(
-        () => {
-          if (!loading) {
-            return setState('IDLE');
-          }
+      const delay = isSSR ? 0 : options.delay;
+      timeout.current = setTimeout(() => {
+        if (!loading) {
+          return setState('IDLE');
+        }
 
-          timeout.current = setTimeout(() => {
-            setState('EXPIRE');
-          }, options.minDuration);
+        timeout.current = setTimeout(() => {
+          setState('EXPIRE');
+        }, options.minDuration);
 
-          setState('DISPLAY');
-        },
-        isSSR ? 0 : options.delay,
-      );
+        setState('DISPLAY');
+      }, delay);
 
       if (!isSSR) {
         setState('DELAY');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,4 +25,3 @@ export declare function useSpinDelay(
   loading: boolean,
   options?: SpinDelayOptions,
 ): boolean;
-export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,28 @@
 interface SpinDelayOptions {
+  /**
+   * The delay in milliseconds before the spinner is displayed.
+   * @default 500
+   */
   delay?: number;
+  /**
+   * The minimum duration in milliseconds the spinner is displayed.
+   * @default 200
+   */
   minDuration?: number;
+  /**
+   * Whether to enable the spinner on the server side. If true, `delay` will be
+   * ignored, and the spinner will be shown immediately if `loading` is true.
+   * @default true
+   */
+  ssr?: boolean;
 }
 export declare const defaultOptions: {
   delay: number;
   minDuration: number;
+  ssr: true;
 };
 export declare function useSpinDelay(
   loading: boolean,
   options?: SpinDelayOptions,
 ): boolean;
+export {};


### PR DESCRIPTION
We now support spinner initialization from the server (SSR). When the `loading` prop is `true` due to server-side rendering, the spinner will be shown immediately. You can opt-out of this behavior by setting the `ssr` option to `false`.

```tsx
import { useSpinDelay } from 'spin-delay';

const spin = useSpinDelay(loading, {
  ssr: false, // defaults to true
});
```