### PR TITLE
fix: override ssr hook when ssr disabled is in options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,8 @@ export function useSpinDelay(
 ): boolean {
   options = Object.assign({}, defaultOptions, options);
 
-  const isSSR = useIsSSR();
-  const initialState = options.ssr && isSSR && loading ? 'DISPLAY' : 'IDLE';
+  const isSSR = useIsSSR() && options.ssr;
+  const initialState = isSSR && loading ? 'DISPLAY' : 'IDLE';
   const [state, setState] = useState<State>(initialState);
   const timeout = useRef(null);
 
@@ -74,7 +74,7 @@ export function useSpinDelay(
       clearTimeout(timeout.current);
       setState('IDLE');
     }
-  }, [loading, state, options.delay, options.minDuration]);
+  }, [loading, state, options.delay, options.minDuration, isSSR]);
 
   useEffect(() => {
     return () => clearTimeout(timeout.current);


### PR DESCRIPTION
Fixes the initial delay used when `options.ssr` is `false`. The effect was only referencing the value from `useIsSSR`, which shouldn't impact behavior if it's disabled in options.